### PR TITLE
8 fix angle offsets

### DIFF
--- a/src/main/java/frc/lib/util/SwerveConstants.java
+++ b/src/main/java/frc/lib/util/SwerveConstants.java
@@ -18,7 +18,7 @@ public final class SwerveConstants {
         public static final boolean invertGyro = false; // Always ensure Gyro is CCW+ CW-
 
         public static final COTSFalconSwerveConstants chosenModule =  //TODO: This must be tuned to specific robot
-            COTSFalconSwerveConstants.SDSMK4(COTSFalconSwerveConstants.driveGearRatios.SDSMK4_L2);
+            COTSFalconSwerveConstants.SDSMK4(COTSFalconSwerveConstants.driveGearRatios.SDSMK4_L1);
 
         /* Drivetrain Constants */
         public static final double trackWidth = Units.inchesToMeters(21.73); //TODO: This must be tuned to specific robot
@@ -61,7 +61,7 @@ public final class SwerveConstants {
         public static final double closedLoopRamp = 0.0;
 
         /* Angle Motor PID Values */
-        public static final double angleKP = 50.0;
+        public static final double angleKP = 5.0;
         public static final double angleKI = 0.01;
         public static final double angleKD = 0.0;
 

--- a/src/main/java/frc/lib/util/SwerveConstants.java
+++ b/src/main/java/frc/lib/util/SwerveConstants.java
@@ -61,9 +61,14 @@ public final class SwerveConstants {
         public static final double closedLoopRamp = 0.0;
 
         /* Angle Motor PID Values */
-        public static final double angleKP = 1.0;
-        public static final double angleKI = 0.0;
+        public static final double angleKP = 50.0;
+        public static final double angleKI = 0.01;
         public static final double angleKD = 0.0;
+
+
+        public static final double angleKS = 0.07; //TODO: This must be tuned to specific robot
+        public static final double angleKV = 0.13;
+        public static final double angleKA = 0.02;
 
         /* Drive Motor PID Values */
         public static final double driveKP = 0.005; //TODO: This must be tuned to specific robot
@@ -86,19 +91,13 @@ public final class SwerveConstants {
         public static final NeutralModeValue angleNeutralMode = NeutralModeValue.Coast;
         public static final NeutralModeValue driveNeutralMode = NeutralModeValue.Brake;
 
-        // Updated encoder offsets, need to convert to degrees and set as angleOffset
-        // Front left: -6368 = 320.625
-        //back left: 19290 = 150.8203125 
-        //front right: -6886 = 229.5703125
-        // back right: -6484 =  300.234375 
-
         /* Module Specific Constants */
         /* Front Left Module - Module 0 */
         public static final class Mod0 { //TODO: This must be tuned to specific robot
             public static final int driveMotorID = 0;
             public static final int angleMotorID = 1;
             public static final int canCoderID = 2;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(320.625);
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(360 - 222.275390625);
 
             public static final SPIKESwerveModConstants constants = 
                 new SPIKESwerveModConstants(driveMotorID, angleMotorID, canCoderID, angleOffset);
@@ -109,7 +108,7 @@ public final class SwerveConstants {
             public static final int driveMotorID = 3;
             public static final int angleMotorID = 4;
             public static final int canCoderID = 5;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(150.8203125);
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(360 - 74.00390625);
 
             public static final SPIKESwerveModConstants constants = 
                 new SPIKESwerveModConstants(driveMotorID, angleMotorID, canCoderID, angleOffset);
@@ -120,7 +119,7 @@ public final class SwerveConstants {
             public static final int driveMotorID = 6;
             public static final int angleMotorID = 7;
             public static final int canCoderID = 8;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(229.5703125);
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(360- 137.98828125 + 23.82);
 
             public static final SPIKESwerveModConstants constants = 
                 new SPIKESwerveModConstants(driveMotorID, angleMotorID, canCoderID, angleOffset);
@@ -131,7 +130,7 @@ public final class SwerveConstants {
             public static final int driveMotorID = 9;
             public static final int angleMotorID = 10;
             public static final int canCoderID = 11;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(300.234375 );
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(360 - 136.494140625);
 
             public static final SPIKESwerveModConstants constants = 
                 new SPIKESwerveModConstants(driveMotorID, angleMotorID, canCoderID, angleOffset);

--- a/src/main/java/frc/robot/CTREConfigs.java
+++ b/src/main/java/frc/robot/CTREConfigs.java
@@ -4,12 +4,14 @@ import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.signals.AbsoluteSensorRangeValue;
 import com.ctre.phoenix6.signals.InvertedValue;
+import com.ctre.phoenix6.signals.NeutralModeValue;
 import com.ctre.phoenix6.signals.SensorDirectionValue;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.Slot0Configs;
 
 import frc.lib.util.COTSFalconSwerveConstants;
 import frc.lib.util.SwerveConstants;
+import frc.lib.util.SwerveConstants.Swerve;
 import frc.lib.util.SPIKESwerveModConstants;
 
 public final class CTREConfigs {
@@ -23,6 +25,15 @@ public final class CTREConfigs {
         CurrentLimitsConfigs angleSupplyLimit = new CurrentLimitsConfigs();
         Slot0Configs anglePIDConfigs = new Slot0Configs();
 
+        /* Angle - Set Inverted*/
+        swerveAngleFXConfig.MotorOutput.Inverted = COTSFalconSwerveConstants.SDSMK4(0).angleMotorInvert;
+        swerveAngleFXConfig.MotorOutput.NeutralMode = NeutralModeValue.Coast;
+
+        /* Angle - Set Continuous Wrap Configs */
+        swerveAngleFXConfig.ClosedLoopGeneral.ContinuousWrap = true;
+        swerveAngleFXConfig.Feedback.RotorToSensorRatio = 1.0;
+        swerveAngleFXConfig.Feedback.SensorToMechanismRatio = COTSFalconSwerveConstants.SDSMK4(0).angleGearRatio;
+
         /* Angle - Set Current Limits */
         angleSupplyLimit.SupplyCurrentLimitEnable = SwerveConstants.Swerve.angleSupplyCurrentLimitEnable;
         angleSupplyLimit.SupplyCurrentLimit = SwerveConstants.Swerve.angleSupplyCurrentLimit;
@@ -34,22 +45,27 @@ public final class CTREConfigs {
         anglePIDConfigs.kI = SwerveConstants.Swerve.angleKI;
         anglePIDConfigs.kD = SwerveConstants.Swerve.angleKD;
 
-        /* Angle - Set Inverted*/
-        swerveAngleFXConfig.MotorOutput.Inverted = COTSFalconSwerveConstants.SDSMK4(SwerveConstants.Swerve.driveGearRatio).angleMotorInvert;
+        anglePIDConfigs.kS = SwerveConstants.Swerve.angleKS;
+        anglePIDConfigs.kV = SwerveConstants.Swerve.angleKV;
+        anglePIDConfigs.kA = SwerveConstants.Swerve.angleKA;
 
-        /* Angle - Set Continuous Wrap Configs */
-        swerveAngleFXConfig.ClosedLoopGeneral.ContinuousWrap = true;
-        swerveAngleFXConfig.Feedback.SensorToMechanismRatio = COTSFalconSwerveConstants.SDSMK4(SwerveConstants.Swerve.driveGearRatio).angleGearRatio; // Set the gear ratio of the motor to the mechanism
-
-        /* Angle - Set Remote Sensor Configs */
-        // We should consider whether or not to use this. We would have to see which way
-        swerveAngleFXConfig.Feedback.FeedbackRemoteSensorID = moduleConstants.cancoderID;
-        swerveAngleFXConfig.Feedback.RotorToSensorRatio = 1.0 / SwerveConstants.Swerve.angleGearRatio; // Set the gear ratio of the motor to the sensor (1:12.8) (12.8 rotations of the motor = 1 rotation of the CANcoder)
+        /* Angle - Disable Limit Switches */
+        swerveAngleFXConfig.HardwareLimitSwitch.ForwardLimitEnable = false;
+        swerveAngleFXConfig.HardwareLimitSwitch.ReverseLimitEnable = false;
+        swerveAngleFXConfig.SoftwareLimitSwitch.ForwardSoftLimitEnable = false;
+        swerveAngleFXConfig.SoftwareLimitSwitch.ReverseSoftLimitEnable = false;
 
         /* Swerve Drive Motor Configuration */
         swerveDriveFXConfig = new TalonFXConfiguration();
         CurrentLimitsConfigs driveSupplyLimit = new CurrentLimitsConfigs();
         Slot0Configs drivePIDConfigs = new Slot0Configs();
+
+        /* Drive - Set Inverted*/
+        swerveDriveFXConfig.MotorOutput.Inverted = COTSFalconSwerveConstants.SDSMK4(SwerveConstants.Swerve.driveGearRatio).driveMotorInvert;
+        swerveDriveFXConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
+
+        /* Drive - Gear Ratio */
+        swerveDriveFXConfig.Feedback.SensorToMechanismRatio = COTSFalconSwerveConstants.SDSMK4(SwerveConstants.Swerve.driveGearRatio).driveGearRatio;
 
         /* Drive - Set Current Limits */
         driveSupplyLimit.SupplyCurrentLimitEnable = SwerveConstants.Swerve.driveSupplyCurrentLimitEnable;
@@ -65,9 +81,6 @@ public final class CTREConfigs {
         drivePIDConfigs.kS = SwerveConstants.Swerve.driveKS;
         drivePIDConfigs.kV = SwerveConstants.Swerve.driveKV;
         drivePIDConfigs.kA = SwerveConstants.Swerve.driveKA;
-
-        /* Drive - Set Inverted*/
-        swerveDriveFXConfig.MotorOutput.Inverted = COTSFalconSwerveConstants.SDSMK4(SwerveConstants.Swerve.driveGearRatio).driveMotorInvert;
 
         /* Swerve CANcoder Configuration */
         swerveCANcoderConfig = new CANcoderConfiguration();

--- a/src/main/java/frc/robot/SwerveModule.java
+++ b/src/main/java/frc/robot/SwerveModule.java
@@ -91,14 +91,25 @@ public class SwerveModule {
      * @param isOpenLoop Whether or not to use open loop control (closed loop PID if false)
      */
     public void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop) {
-        // if (desiredState.speedMetersPerSecond < 0.2) {
-        //     stop();
-        //     return;
-        // }
-
-        // desiredState = CTREModuleState.optimize(desiredState, Rotation2d.fromRotations(getState().angle.getRotations() + );
+        desiredState = optimize(desiredState);
         setAngle(desiredState);
         setSpeed(desiredState, isOpenLoop);
+    }
+
+    public SwerveModuleState optimize(SwerveModuleState desiredState) {
+        double newRotation = desiredState.angle.getRotations() % 1.0;
+        double currentRotation = getAngle().getRotations() % 1.0;
+
+        double angleDifference = (newRotation - currentRotation + 0.5) % 1.0 - 0.5;
+
+        if (Math.abs(angleDifference) > 0.25) {
+            newRotation += 0.5;
+            desiredState.speedMetersPerSecond *= -1;
+        }
+
+        desiredState.angle = Rotation2d.fromRotations(newRotation % 1.0);
+
+        return desiredState;
     }
 
     /**

--- a/src/main/java/frc/robot/SwerveModule.java
+++ b/src/main/java/frc/robot/SwerveModule.java
@@ -2,6 +2,7 @@ package frc.robot;
 
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -47,15 +48,17 @@ public class SwerveModule {
 
         // Angle encoder config
         m_angleEncoder = new CANcoder(moduleConstants.cancoderID);
-        configAngleEncoder();
+        m_angleEncoder.getConfigurator().apply(m_configs.swerveCANcoderConfig);
 
         // Angle motor config
         m_angleMotor = new TalonFX(moduleConstants.angleMotorID);
-        configAngleMotor();
+        m_angleMotor.getConfigurator().apply(m_configs.swerveAngleFXConfig);
+        resetToAbsolute();
 
         // Drive motor config
         m_driveMotor = new TalonFX(moduleConstants.driveMotorID);
-        configDriveMotor();
+        m_driveMotor.getConfigurator().apply(m_configs.swerveDriveFXConfig);
+        m_driveMotor.setPosition(0);
 
         m_lastAngle = getState().angle;
 
@@ -73,17 +76,27 @@ public class SwerveModule {
     }
 
     /**
+     * Resets the angle of the angle motor module to absolute (read from CANcoder)
+     */
+    public void resetToAbsolute() {
+        // Convert the CANcoder's degrees to motor rotations
+        double rotations = getCANcoder().getRotations();
+        m_angleMotor.setPosition(rotations);
+        m_targetRotations = rotations;
+    }
+
+    /**
      * Sets the desired state of the module
      * @param desiredState The desired state of the module
      * @param isOpenLoop Whether or not to use open loop control (closed loop PID if false)
      */
     public void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop) {
-        if (desiredState.speedMetersPerSecond < 0.2) {
-            stop();
-            return;
-        }
+        // if (desiredState.speedMetersPerSecond < 0.2) {
+        //     stop();
+        //     return;
+        // }
 
-        desiredState = CTREModuleState.optimize(desiredState, getState().angle);
+        // desiredState = CTREModuleState.optimize(desiredState, Rotation2d.fromRotations(getState().angle.getRotations() + );
         setAngle(desiredState);
         setSpeed(desiredState, isOpenLoop);
     }
@@ -93,7 +106,6 @@ public class SwerveModule {
      * @param neutralMode The neutral mode to set the motors to
      */
     public void setNeutralMode(NeutralModeValue neutralMode) {
-        m_angleMotor.setNeutralMode(neutralMode);
         m_driveMotor.setNeutralMode(neutralMode);
     }
 
@@ -118,8 +130,9 @@ public class SwerveModule {
      */
     public void setAngle(SwerveModuleState desiredState) {
         Rotation2d angle = (Math.abs(desiredState.speedMetersPerSecond) <= (SwerveConstants.Swerve.maxSpeed * 0.01)) ? m_lastAngle : desiredState.angle; // Prevent rotating module if speed is less than 1%. Prevents jittering
+        // Rotation2d angle = desiredState.angle;
 
-        m_targetRotations = Conversions.degreesToFalconRotations(angle.getDegrees(), SwerveConstants.Swerve.angleGearRatio);
+        m_targetRotations = angle.getRotations();
 
         m_angleMotor.setControl(m_angleSetter.withPosition(m_targetRotations));
         m_lastAngle = angle;
@@ -130,16 +143,7 @@ public class SwerveModule {
      * @return The angle of the module
      */
     public Rotation2d getCANcoder() {
-        return Rotation2d.fromDegrees(
-            Conversions.CANcoderToDegrees(
-                /* The reason I set the gear ratio to 1 is because I believe that the
-                CANcoder is reading the rotation of the module itself, not the angle motor
-                so the ratio would be 1:1 */
-                m_angleEncoder.getAbsolutePosition().getValue(), 1.0
-            )
-            // Might have to swap the sign of the offset to negative (check this)
-            + m_angleOffset.getDegrees()
-        );
+        return Rotation2d.fromRotations(m_angleEncoder.getAbsolutePosition().getValue() + m_angleOffset.getRotations() % 1.0);
     }
 
     /**
@@ -155,10 +159,10 @@ public class SwerveModule {
 
     /**
      * Gets the angle of the module
-     * @return The angle of the module
+     * @return The angle of the module (in rotations)
      */
     public Rotation2d getAngle() {
-        return Rotation2d.fromDegrees(Conversions.falconRotationsToDegrees(m_angleMotor.getPosition().getValue(), SwerveConstants.Swerve.angleGearRatio) + m_angleOffset.getDegrees());
+        return Rotation2d.fromRotations(m_angleMotor.getPosition().getValue());
     }
 
     /**
@@ -170,39 +174,5 @@ public class SwerveModule {
             Conversions.falconToMeters(m_driveMotor.getPosition().getValue(), SwerveConstants.Swerve.wheelCircumference, SwerveConstants.Swerve.driveGearRatio),
             getAngle()
         );
-    }
-
-    /**
-     * Resets the angle of the angle motor module to absolute (read from CANcoder)
-     */
-    public void resetToAbsolute() {
-        // Convert the CANcoder's degrees to motor rotations
-        double rotations = Conversions.degreesToFalconRotations(getCANcoder().getDegrees() - m_angleOffset.getDegrees(), SwerveConstants.Swerve.angleGearRatio);
-        m_angleMotor.setPosition(rotations);
-    }
-
-    /**
-     * Configures the angle encoder
-     */
-    public void configAngleEncoder() {
-        m_angleEncoder.getConfigurator().apply(m_configs.swerveCANcoderConfig);
-    }
-
-    /**
-     * Configures the angle motor
-     */
-    public void configAngleMotor() {
-        m_angleMotor.getConfigurator().apply(m_configs.swerveAngleFXConfig);
-        m_angleMotor.setNeutralMode(SwerveConstants.Swerve.driveNeutralMode);
-        resetToAbsolute();
-    }
-
-    /**
-     * Configures the drive motor
-     */
-    public void configDriveMotor() {
-        m_driveMotor.getConfigurator().apply(m_configs.swerveDriveFXConfig);
-        m_driveMotor.setNeutralMode(SwerveConstants.Swerve.driveNeutralMode);
-        m_driveMotor.setPosition(0);
     }
 }

--- a/src/main/java/frc/robot/classes/SpikeController.java
+++ b/src/main/java/frc/robot/classes/SpikeController.java
@@ -32,11 +32,11 @@ public class SpikeController {
     }
 
     public Rotation2d getLeftDirection() {
-        return new Rotation2d(m_controller.getLeftX(), -m_controller.getLeftY());
+        return new Rotation2d(getLeftX(), getLeftY());
     }
 
     public Rotation2d getRightDirection() {
-        return new Rotation2d(m_controller.getRightX(), -m_controller.getRightY());
+        return new Rotation2d(getRightX(), getRightY());
     }
 
     public double getLeftMagnitude() {
@@ -52,13 +52,13 @@ public class SpikeController {
     public double getLeftX() {
         double axisValue = deadband(m_controller.getLeftX(), m_deadband);
         SmartDashboard.putNumber(m_name + "Left X", axisValue);
-        return axisValue;
+        return -axisValue;
     }
 
     public double getLeftY() {
         double axisValue = deadband(m_controller.getLeftY(), m_deadband);
         SmartDashboard.putNumber(m_name + " Left Y", axisValue);
-        return axisValue;
+        return -axisValue;
     }
 
     public boolean getLeftStickButton() {
@@ -68,13 +68,13 @@ public class SpikeController {
     public double getRightX() {
         double axisValue = deadband(m_controller.getRightX(), m_deadband);
         SmartDashboard.putNumber(m_name + " Right X", axisValue);
-        return axisValue;
+        return -axisValue;
     }
 
     public double getRightY() {
         double axisValue = deadband(m_controller.getRightY(), m_deadband);
         SmartDashboard.putNumber(m_name + " Right Y", axisValue);
-        return axisValue;
+        return -axisValue;
     }
 
     public boolean getRightStickButton() {

--- a/src/main/java/frc/robot/commands/OrientedDrive.java
+++ b/src/main/java/frc/robot/commands/OrientedDrive.java
@@ -12,7 +12,6 @@ package frc.robot.commands;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.classes.SpikeController;
 import frc.robot.subsystems.Drivetrain;
@@ -44,12 +43,9 @@ public class OrientedDrive extends Command {
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
-        double translationMagnitude = m_controller.getRightMagnitude() * MAX_TRANSLATION_VELOCITY;
-        Rotation2d translationAngle = m_controller.getRightDirection();
-
+        Translation2d robotTranslation = new Translation2d(m_controller.getRightY(), m_controller.getRightX());
+        
         double rotationSpeed = m_controller.getLeftX() * MAX_ROTATION_VELOCITY;
-
-        Translation2d robotTranslation = new Translation2d(translationMagnitude, translationAngle);
 
         m_drivetrain.drive(robotTranslation, rotationSpeed, m_fieldOriented, false);
     }

--- a/src/main/java/frc/robot/commands/OrientedDrive.java
+++ b/src/main/java/frc/robot/commands/OrientedDrive.java
@@ -26,7 +26,7 @@ public class OrientedDrive extends Command {
     private final boolean m_fieldOriented;
 
     private final double MAX_TRANSLATION_VELOCITY = 3.0d;
-    private final double MAX_ROTATION_VELOCITY_RAD = 0.15d;
+    private final double MAX_ROTATION_VELOCITY = 3.0d;
 
     public OrientedDrive(Drivetrain drivetrain, SpikeController controller, boolean fieldOriented) {
         m_drivetrain = drivetrain;
@@ -47,14 +47,10 @@ public class OrientedDrive extends Command {
         double translationMagnitude = m_controller.getRightMagnitude() * MAX_TRANSLATION_VELOCITY;
         Rotation2d translationAngle = m_controller.getRightDirection();
 
+        double rotationSpeed = m_controller.getLeftX() * MAX_ROTATION_VELOCITY;
+
         Translation2d robotTranslation = new Translation2d(translationMagnitude, translationAngle);
 
-        if (m_controller.getYButton()) {
-            robotTranslation = new Translation2d(0, 1);
-        }
-
-        // Implement rotation, currently broken
-
-        m_drivetrain.drive(robotTranslation, 0, m_fieldOriented, false);
+        m_drivetrain.drive(robotTranslation, rotationSpeed, m_fieldOriented, false);
     }
 }

--- a/src/main/java/frc/robot/commands/OrientedDrive.java
+++ b/src/main/java/frc/robot/commands/OrientedDrive.java
@@ -12,6 +12,7 @@ package frc.robot.commands;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.classes.SpikeController;
 import frc.robot.subsystems.Drivetrain;
@@ -43,10 +44,14 @@ public class OrientedDrive extends Command {
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
-        double translationMagnitude = m_controller.getLeftMagnitude() * MAX_TRANSLATION_VELOCITY;
-        Rotation2d translationAngle = m_controller.getLeftDirection();
+        double translationMagnitude = m_controller.getRightMagnitude() * MAX_TRANSLATION_VELOCITY;
+        Rotation2d translationAngle = m_controller.getRightDirection();
 
         Translation2d robotTranslation = new Translation2d(translationMagnitude, translationAngle);
+
+        if (m_controller.getYButton()) {
+            robotTranslation = new Translation2d(0, 1);
+        }
 
         // Implement rotation, currently broken
 

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -71,7 +71,7 @@ public class Drivetrain extends SubsystemBase {
                                     translation.getX(),
                                     translation.getY(),
                                     rotationSpeed,
-                                    Rotation2d.fromDegrees(getYaw().getDegrees() - 45)
+                                    getYaw()
                                 )
                                 : new ChassisSpeeds(
                                     translation.getX(),
@@ -100,6 +100,10 @@ public class Drivetrain extends SubsystemBase {
         SmartDashboard.putNumber("Robot X (SwerveOdometry)", robotTranslation.getTranslation().getX());
         SmartDashboard.putNumber("Robot Y (SwerveOdometry)", robotTranslation.getTranslation().getY());
         SmartDashboard.putNumber("Robot Angle (SwerveOdometry)", robotTranslation.getRotation().getDegrees());
+
+        SmartDashboard.putNumber("Robot Yaw (Z)",  ((gyro.getYaw() % 360.0)));
+        SmartDashboard.putNumber("Robot Pitch (X)",  ((gyro.getPitch() % 360.0)));
+        SmartDashboard.putNumber("Robot Roll (Y)",  ((gyro.getRoll() % 360.0)));
 
         SmartDashboard.putNumber("Yaw", getYaw().getDegrees());
 
@@ -150,7 +154,7 @@ public class Drivetrain extends SubsystemBase {
     }
 
     public Rotation2d getYaw() {
-        return Rotation2d.fromDegrees(gyro.getAngle());
+        return Rotation2d.fromDegrees(-gyro.getAngle() % 360.0);
     }
 
     public void resetModulesToAbsolute() {

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -42,6 +42,7 @@ public class Drivetrain extends SubsystemBase {
     public Drivetrain() {
         gyro = new AHRS(SerialPort.Port.kMXP);
         gyro.reset();
+        zeroGyro();
 
         // Create modules from the constant values in SwerveConstants
         m_swerveModules = new SwerveModule[] {
@@ -57,6 +58,10 @@ public class Drivetrain extends SubsystemBase {
 
         // Create a new swerve odometry object, similar to the Kinematics.java file before
         m_swerveOdometry = new SwerveDriveOdometry(SwerveConstants.Swerve.swerveKinematics, getYaw(), getModulePositions());
+    
+        for (SwerveModule module : m_swerveModules) {
+            module.setDesiredState(new SwerveModuleState(0, Rotation2d.fromDegrees(0)), false);
+        }
     }
 
     public void drive(Translation2d translation, double rotationSpeed, boolean fieldRelative, boolean isOpenLoop) {
@@ -66,7 +71,7 @@ public class Drivetrain extends SubsystemBase {
                                     translation.getX(),
                                     translation.getY(),
                                     rotationSpeed,
-                                    getYaw()
+                                    Rotation2d.fromDegrees(0) // getYaw()
                                 )
                                 : new ChassisSpeeds(
                                     translation.getX(),
@@ -97,7 +102,7 @@ public class Drivetrain extends SubsystemBase {
         SmartDashboard.putNumber("Robot Angle (SwerveOdometry)", robotTranslation.getRotation().getDegrees());
 
         for (SwerveModule module : m_swerveModules) {
-            SmartDashboard.putNumber("Mod " + module.m_moduleNumber + " Module (degrees)", module.getAngle().getDegrees() );
+            SmartDashboard.putNumber("Mod " + module.m_moduleNumber + " Module (degrees)", module.getAngle().getDegrees() % 360);
             SmartDashboard.putNumber("Mod " + module.m_moduleNumber + " CANcoder (degrees)", module.getCANcoder().getDegrees() % 360);
             SmartDashboard.putNumber("Mod " + module.m_moduleNumber + " Meters/Sec", module.getState().speedMetersPerSecond);
             SmartDashboard.putNumber("Mod " + module.m_moduleNumber + " Target rotations", module.m_targetRotations);

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -71,7 +71,7 @@ public class Drivetrain extends SubsystemBase {
                                     translation.getX(),
                                     translation.getY(),
                                     rotationSpeed,
-                                    Rotation2d.fromDegrees(0) // getYaw()
+                                    Rotation2d.fromDegrees(getYaw().getDegrees() - 45)
                                 )
                                 : new ChassisSpeeds(
                                     translation.getX(),
@@ -100,6 +100,8 @@ public class Drivetrain extends SubsystemBase {
         SmartDashboard.putNumber("Robot X (SwerveOdometry)", robotTranslation.getTranslation().getX());
         SmartDashboard.putNumber("Robot Y (SwerveOdometry)", robotTranslation.getTranslation().getY());
         SmartDashboard.putNumber("Robot Angle (SwerveOdometry)", robotTranslation.getRotation().getDegrees());
+
+        SmartDashboard.putNumber("Yaw", getYaw().getDegrees());
 
         for (SwerveModule module : m_swerveModules) {
             SmartDashboard.putNumber("Mod " + module.m_moduleNumber + " Module (degrees)", module.getAngle().getDegrees() % 360);

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -58,10 +58,6 @@ public class Drivetrain extends SubsystemBase {
 
         // Create a new swerve odometry object, similar to the Kinematics.java file before
         m_swerveOdometry = new SwerveDriveOdometry(SwerveConstants.Swerve.swerveKinematics, getYaw(), getModulePositions());
-    
-        for (SwerveModule module : m_swerveModules) {
-            module.setDesiredState(new SwerveModuleState(0, Rotation2d.fromDegrees(0)), false);
-        }
     }
 
     public void drive(Translation2d translation, double rotationSpeed, boolean fieldRelative, boolean isOpenLoop) {


### PR DESCRIPTION
This code now restores the robot to it's functionally demonstrated state as of Tuesday, January 3, as well as adding rotation ability.

Changes:
- Added rotation as an ability to the swerve bot
- Modifications to PID motor control
- Changing the angle offsets of the motors
- Reformatting and fixing the code in SwerveModule
- Adding control abilities in OrientedDrive:
  - Importantly, this swaps the control of the robot translation to the right joystick of the controller and rotation to the left joystick in anticipation of using the D-Pad for snap turning, which will allow the left thumb to control rotation while driving at the same time without discomfort.

Successfully demonstrated to be working 1/14/24, but is drifting and requires tuning (#5 and #7)

Fixes #3 and fixes #8