### PR TITLE
24 robot pose not not updating

### DIFF
--- a/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/commands/DriveCommands.java
@@ -22,7 +22,6 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.subsystems.drive.Drive;
-
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 
@@ -70,32 +69,28 @@ public class DriveCommands {
         drive);
   }
 
-    // Simulate a car with front wheel drive
-    // Gas is right trigger, brake is left trigger
-    // Steering is left joystick x axis or right joystick x axis
-    public static Command kartDrive(
-        Drive drive,
-        DoubleSupplier gasSupplier,
-        DoubleSupplier brakeSupplier,
-        DoubleSupplier steeringSupplier,
-        BooleanSupplier reverseGear) {
-        return Commands.run(
+  // Simulate a car with front wheel drive
+  // Gas is right trigger, brake is left trigger
+  // Steering is left joystick x axis or right joystick x axis
+  public static Command kartDrive(
+      Drive drive,
+      DoubleSupplier gasSupplier,
+      DoubleSupplier brakeSupplier,
+      DoubleSupplier steeringSupplier,
+      BooleanSupplier reverseGear) {
+    return Commands.run(
         () -> {
-            double gas = gasSupplier.getAsDouble();
-            double brake = brakeSupplier.getAsDouble();
-            double steering = steeringSupplier.getAsDouble();
-            double speed = gas - brake;
-            if (reverseGear.getAsBoolean()) {
-                speed *= -1;
-            }
-            boolean brakeMotors = brake >= 0.75 ? false : true;
-            drive.runFrontWheelDrive(
-                    speed * drive.getMaxLinearSpeedMetersPerSec(),
-                    steering,
-                    brakeMotors,
-                    45.0
-                );
+          double gas = gasSupplier.getAsDouble();
+          double brake = brakeSupplier.getAsDouble();
+          double steering = steeringSupplier.getAsDouble();
+          double speed = gas - brake;
+          if (reverseGear.getAsBoolean()) {
+            speed *= -1;
+          }
+          boolean brakeMotors = brake >= 0.75 ? false : true;
+          drive.runFrontWheelDrive(
+              speed * drive.getMaxLinearSpeedMetersPerSec(), steering, brakeMotors, 45.0);
         },
         drive);
-    }
+  }
 }

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -114,8 +114,8 @@ public class Drive extends SubsystemBase {
     }
 
     // Update odometry
-    int deltaCount =
-        gyroInputs.connected ? gyroInputs.odometryYawPositions.length : Integer.MAX_VALUE;
+    int deltaCount = Integer.MAX_VALUE;
+    // gyroInputs.connected ? gyroInputs.odometryYawPositions.length : Integer.MAX_VALUE;
     for (int i = 0; i < 4; i++) {
       deltaCount = Math.min(deltaCount, modules[i].getPositionDeltas().length);
     }
@@ -133,13 +133,15 @@ public class Drive extends SubsystemBase {
       if (gyroInputs.connected) {
         // If the gyro is connected, replace the theta component of the twist
         // with the change in angle since the last sample.
-        Rotation2d gyroRotation = gyroInputs.odometryYawPositions[deltaIndex];
-        twist = new Twist2d(twist.dx, twist.dy, gyroRotation.minus(lastGyroRotation).getRadians());
-        lastGyroRotation = gyroRotation;
+        Rotation2d gyroRotation = gyroInputs.yawPosition;
+        twist =
+            new Twist2d(
+                twist.dx, twist.dy, gyroRotation.minus(lastGyroRotation).getRadians() / deltaCount);
       }
       // Apply the twist (change since last sample) to the current pose
       pose = pose.exp(twist);
     }
+    lastGyroRotation = gyroInputs.yawPosition;
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -165,56 +165,49 @@ public class Drive extends SubsystemBase {
     Logger.recordOutput("SwerveStates/SetpointsOptimized", optimizedSetpointStates);
   }
 
-    /**
-     * Runs the drive as if it was a car with front wheel drive
-     *
-     * @param speedMetersPerSec in meters/sec
-     * @param steering Steering input from -1 to 1
-     * @param brake Whether to brake
-     * @param reverse Whether to reverse
-     * @param maxTurningAngle Maximum turning angle in degrees
-     */
-    public void runFrontWheelDrive(
-        double speedMetersPerSec,
-        double steering,
-        boolean brake,
-        double maxTurningAngle) {
-        // Calculate module setpoints
-        SwerveModuleState frontWheels = new SwerveModuleState(
+  /**
+   * Runs the drive as if it was a car with front wheel drive
+   *
+   * @param speedMetersPerSec in meters/sec
+   * @param steering Steering input from -1 to 1
+   * @param brake Whether to brake
+   * @param reverse Whether to reverse
+   * @param maxTurningAngle Maximum turning angle in degrees
+   */
+  public void runFrontWheelDrive(
+      double speedMetersPerSec, double steering, boolean brake, double maxTurningAngle) {
+    // Calculate module setpoints
+    SwerveModuleState frontWheels =
+        new SwerveModuleState(
             speedMetersPerSec,
-            new Rotation2d(0)
-            .minus(Rotation2d.fromDegrees(steering * maxTurningAngle))
-        );
-        SwerveModuleState backWheels = new SwerveModuleState(
-            speedMetersPerSec,
-            new Rotation2d(0)
-        );
-        SwerveModuleState[] setpointStates = {
-            SwerveModuleState.optimize(frontWheels, new Rotation2d()),
-            SwerveModuleState.optimize(frontWheels, new Rotation2d()),
-            SwerveModuleState.optimize(backWheels, new Rotation2d()),
-            SwerveModuleState.optimize(backWheels, new Rotation2d())
-        };
-        SwerveDriveKinematics.desaturateWheelSpeeds(setpointStates, MAX_LINEAR_SPEED);
+            new Rotation2d(0).minus(Rotation2d.fromDegrees(steering * maxTurningAngle)));
+    SwerveModuleState backWheels = new SwerveModuleState(speedMetersPerSec, new Rotation2d(0));
+    SwerveModuleState[] setpointStates = {
+      SwerveModuleState.optimize(frontWheels, new Rotation2d()),
+      SwerveModuleState.optimize(frontWheels, new Rotation2d()),
+      SwerveModuleState.optimize(backWheels, new Rotation2d()),
+      SwerveModuleState.optimize(backWheels, new Rotation2d())
+    };
+    SwerveDriveKinematics.desaturateWheelSpeeds(setpointStates, MAX_LINEAR_SPEED);
 
-        // Send setpoints to modules
-        SwerveModuleState[] optimizedSetpointStates = new SwerveModuleState[4];
-        for (int i = 0; i < 4; i++) {
-            // The module returns the optimized state, useful for logging
-            optimizedSetpointStates[i] = modules[i].runSetpoint(setpointStates[i]);
+    // Send setpoints to modules
+    SwerveModuleState[] optimizedSetpointStates = new SwerveModuleState[4];
+    for (int i = 0; i < 4; i++) {
+      // The module returns the optimized state, useful for logging
+      optimizedSetpointStates[i] = modules[i].runSetpoint(setpointStates[i]);
 
-            if (brake) {
-                modules[i].setDriveBrakeMode(true);
-                continue;
-            }
+      if (brake) {
+        modules[i].setDriveBrakeMode(true);
+        continue;
+      }
 
-            modules[i].setDriveBrakeMode(false);
-        }
-
-        // Log setpoint states
-        Logger.recordOutput("SwerveStates/Setpoints", setpointStates);
-        Logger.recordOutput("SwerveStates/SetpointsOptimized", optimizedSetpointStates);
+      modules[i].setDriveBrakeMode(false);
     }
+
+    // Log setpoint states
+    Logger.recordOutput("SwerveStates/Setpoints", setpointStates);
+    Logger.recordOutput("SwerveStates/SetpointsOptimized", optimizedSetpointStates);
+  }
 
   /** Stops the drive. */
   public void stop() {
@@ -268,7 +261,7 @@ public class Drive extends SubsystemBase {
 
   /** Returns the current odometry rotation. */
   public Rotation2d getRotation() {
-    return pose.getRotation();
+    return gyroInputs.yawPosition;
   }
 
   /** Resets the current odometry pose. */

--- a/src/main/java/frc/robot/subsystems/drive/GyroIONavX.java
+++ b/src/main/java/frc/robot/subsystems/drive/GyroIONavX.java
@@ -21,6 +21,7 @@ import edu.wpi.first.wpilibj.SerialPort;
 /** IO implementation for NavX */
 public class GyroIONavX implements GyroIO {
   public final AHRS gyro = new AHRS(SerialPort.Port.kMXP);
+  public static final boolean INVERTED = true;
 
   public GyroIONavX() {
     gyro.reset();
@@ -33,7 +34,7 @@ public class GyroIONavX implements GyroIO {
   @Override
   public void updateInputs(GyroIOInputs inputs) {
     inputs.connected = true;
-    inputs.yawPosition = Rotation2d.fromDegrees(gyro.getYaw());
+    inputs.yawPosition = Rotation2d.fromDegrees(gyro.getYaw() * (INVERTED ? -1.0 : 1.0));
     inputs.yawVelocityRadPerSec = Units.degreesToRadians(gyro.getRate());
     inputs.pose = gyro.getRotation3d();
   }

--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -25,6 +25,7 @@ import org.littletonrobotics.junction.Logger;
 
 public class Module {
   private static final double WHEEL_RADIUS = Units.inchesToMeters(2.0);
+  private static final double WHEEL_CIRCUMFERENCE = 2.0 * WHEEL_RADIUS * Math.PI;
   public static final double ODOMETRY_FREQUENCY = 250.0;
 
   private final ModuleIO io;
@@ -125,7 +126,7 @@ public class Module {
             inputs.odometryDrivePositionsRotations.length, inputs.odometryTurnPositions.length);
     positionDeltas = new SwerveModulePosition[deltaCount];
     for (int i = 0; i < deltaCount; i++) {
-      double positionMeters = inputs.odometryDrivePositionsRotations[i] * WHEEL_RADIUS;
+      double positionMeters = inputs.odometryDrivePositionsRotations[i] * WHEEL_CIRCUMFERENCE;
       Rotation2d angle =
           inputs.odometryTurnPositions[i].plus(
               turnRelativeOffset != null ? turnRelativeOffset : new Rotation2d());
@@ -189,12 +190,12 @@ public class Module {
 
   /** Returns the current drive position of the module in meters. */
   public double getPositionMeters() {
-    return inputs.drivePositionRotations * WHEEL_RADIUS;
+    return inputs.drivePositionRotations * WHEEL_CIRCUMFERENCE;
   }
 
   /** Returns the current drive velocity of the module in meters per second. */
   public double getVelocityMetersPerSec() {
-    return inputs.driveVelocityRotationsPerSec * WHEEL_RADIUS;
+    return inputs.driveVelocityRotationsPerSec * WHEEL_CIRCUMFERENCE;
   }
 
   /** Returns the module position (turn angle and drive position). */

--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -115,16 +115,17 @@ public class Module {
         double velocityRadPerSec = adjustSpeedSetpoint / WHEEL_RADIUS;
         io.setDriveVoltage(
             driveFeedforward.calculate(velocityRadPerSec)
-                + driveFeedback.calculate(inputs.driveVelocityRadPerSec, velocityRadPerSec));
+                + driveFeedback.calculate(inputs.driveVelocityRotationsPerSec, velocityRadPerSec));
       }
     }
 
     // Calculate position deltas for odometry
     int deltaCount =
-        Math.min(inputs.odometryDrivePositionsRad.length, inputs.odometryTurnPositions.length);
+        Math.min(
+            inputs.odometryDrivePositionsRotations.length, inputs.odometryTurnPositions.length);
     positionDeltas = new SwerveModulePosition[deltaCount];
     for (int i = 0; i < deltaCount; i++) {
-      double positionMeters = inputs.odometryDrivePositionsRad[i] * WHEEL_RADIUS;
+      double positionMeters = inputs.odometryDrivePositionsRotations[i] * WHEEL_RADIUS;
       Rotation2d angle =
           inputs.odometryTurnPositions[i].plus(
               turnRelativeOffset != null ? turnRelativeOffset : new Rotation2d());
@@ -188,12 +189,12 @@ public class Module {
 
   /** Returns the current drive position of the module in meters. */
   public double getPositionMeters() {
-    return inputs.drivePositionRad * WHEEL_RADIUS;
+    return inputs.drivePositionRotations * WHEEL_RADIUS;
   }
 
   /** Returns the current drive velocity of the module in meters per second. */
   public double getVelocityMetersPerSec() {
-    return inputs.driveVelocityRadPerSec * WHEEL_RADIUS;
+    return inputs.driveVelocityRotationsPerSec * WHEEL_RADIUS;
   }
 
   /** Returns the module position (turn angle and drive position). */
@@ -213,6 +214,6 @@ public class Module {
 
   /** Returns the drive velocity in radians/sec. */
   public double getCharacterizationVelocity() {
-    return inputs.driveVelocityRadPerSec;
+    return inputs.driveVelocityRotationsPerSec;
   }
 }

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIO.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIO.java
@@ -19,8 +19,8 @@ import org.littletonrobotics.junction.AutoLog;
 public interface ModuleIO {
   @AutoLog
   public static class ModuleIOInputs {
-    public double drivePositionRad = 0.0;
-    public double driveVelocityRadPerSec = 0.0;
+    public double drivePositionRotations = 0.0;
+    public double driveVelocityRotationsPerSec = 0.0;
     public double driveAppliedVolts = 0.0;
     public double[] driveCurrentAmps = new double[] {};
 
@@ -31,7 +31,7 @@ public interface ModuleIO {
     public double turnAppliedVolts = 0.0;
     public double[] turnCurrentAmps = new double[] {};
 
-    public double[] odometryDrivePositionsRad = new double[] {};
+    public double[] odometryDrivePositionsRotations = new double[] {};
     public Rotation2d[] odometryTurnPositions = new Rotation2d[] {};
 
     public double canCoderRotations = 0.0;

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOSim.java
@@ -43,8 +43,8 @@ public class ModuleIOSim implements ModuleIO {
     driveSim.update(LOOP_PERIOD_SECS);
     turnSim.update(LOOP_PERIOD_SECS);
 
-    inputs.drivePositionRad = driveSim.getAngularPositionRad();
-    inputs.driveVelocityRadPerSec = driveSim.getAngularVelocityRadPerSec();
+    inputs.drivePositionRotations = driveSim.getAngularPositionRad();
+    inputs.driveVelocityRotationsPerSec = driveSim.getAngularVelocityRadPerSec();
     inputs.driveAppliedVolts = driveAppliedVolts;
     inputs.driveCurrentAmps = new double[] {Math.abs(driveSim.getCurrentDrawAmps())};
 
@@ -55,7 +55,7 @@ public class ModuleIOSim implements ModuleIO {
     inputs.turnAppliedVolts = turnAppliedVolts;
     inputs.turnCurrentAmps = new double[] {Math.abs(turnSim.getCurrentDrawAmps())};
 
-    inputs.odometryDrivePositionsRad = new double[] {inputs.drivePositionRad};
+    inputs.odometryDrivePositionsRotations = new double[] {inputs.drivePositionRotations};
     inputs.odometryTurnPositions = new Rotation2d[] {inputs.turnPosition};
   }
 

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
@@ -166,10 +166,8 @@ public class ModuleIOTalonFX implements ModuleIO {
     inputs.canCoderRotations = cancoder.getAbsolutePosition().getValue();
     inputs.canCoderAngle = Units.rotationsToDegrees(inputs.canCoderRotations);
 
-    inputs.drivePositionRad =
-        Units.rotationsToRadians(drivePosition.getValueAsDouble()) / DRIVE_GEAR_RATIO;
-    inputs.driveVelocityRadPerSec =
-        Units.rotationsToRadians(driveVelocity.getValueAsDouble()) / DRIVE_GEAR_RATIO;
+    inputs.drivePositionRotations = drivePosition.getValueAsDouble() / DRIVE_GEAR_RATIO;
+    inputs.driveVelocityRotationsPerSec = driveVelocity.getValueAsDouble() / DRIVE_GEAR_RATIO;
     inputs.driveAppliedVolts = driveAppliedVolts.getValueAsDouble();
     inputs.driveCurrentAmps = new double[] {driveCurrent.getValueAsDouble()};
 
@@ -182,9 +180,9 @@ public class ModuleIOTalonFX implements ModuleIO {
     inputs.turnAppliedVolts = turnAppliedVolts.getValueAsDouble();
     inputs.turnCurrentAmps = new double[] {turnCurrent.getValueAsDouble()};
 
-    inputs.odometryDrivePositionsRad =
+    inputs.odometryDrivePositionsRotations =
         drivePositionQueue.stream()
-            .mapToDouble((Double value) -> Units.rotationsToRadians(value) / DRIVE_GEAR_RATIO)
+            .mapToDouble((Double value) -> value / DRIVE_GEAR_RATIO)
             .toArray();
     inputs.odometryTurnPositions =
         turnPositionQueue.stream()


### PR DESCRIPTION
The robot pose was not updating based on wheel movement or gyro changes. This was fixed and can now move in correct direction and displays correct orientation in advantagekit.

Problems still include drifting and incorrect scaling values. Robot moves correctly around the field but the conversion to the real world may not be correct.

Fixes #24 